### PR TITLE
Inkpot Variable Watch improvements

### DIFF
--- a/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
+++ b/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
@@ -1,0 +1,78 @@
+#include "Inkpot/AsyncActions/AsyncAction_WaitVariableChange.h"
+#include "Inkpot/Inkpot.h"
+#include "Inkpot/InkpotStory.h"
+
+UAsyncAction_WaitVariableChange* UAsyncAction_WaitVariableChange::ListenForVariableChange(UObject* WorldContextObject, const FString& VariableToListen, const bool bTriggerOnce)
+{
+	UAsyncAction_WaitVariableChange* AsyncTask = NewObject<UAsyncAction_WaitVariableChange>();
+	AsyncTask->VariableToListen = VariableToListen;
+	AsyncTask->bTriggerOnce = bTriggerOnce;
+	AsyncTask->World = WorldContextObject->GetWorld();
+	AsyncTask->RegisterWithGameInstance(WorldContextObject);
+	return AsyncTask;
+}
+
+void UAsyncAction_WaitVariableChange::Activate()
+{
+	if (!GEngine || !World || VariableToListen.IsEmpty())
+	{
+		EndTask();
+		return;
+	}
+
+	Inkpot = GEngine->GetEngineSubsystem<UInkpot>();
+	check(Inkpot);
+	Inkpot->EventOnStoryBegin.AddUniqueDynamic(this, &UAsyncAction_WaitVariableChange::OnBeginStory);
+}
+
+void UAsyncAction_WaitVariableChange::OnBeginStory(UInkpotStory* InStory)
+{
+	CurrentStory = InStory;
+	
+	check(Inkpot);
+	Inkpot->EventOnStoryEnd.AddUniqueDynamic(this, &UAsyncAction_WaitVariableChange::OnEndStory);
+	
+	FOnVariableChange Delegate;
+	Delegate.BindDynamic(this, &UAsyncAction_WaitVariableChange::OnVariableChange);
+	InStory->SetOnVariableChange(Delegate, VariableToListen);
+}
+
+void UAsyncAction_WaitVariableChange::OnVariableChange(UInkpotStory* InStory, const FString& InVariable, const FInkpotValue& NewValue)
+{
+	OnVariableChangeDelegate.Broadcast(InStory, InVariable, NewValue);
+
+	if (bTriggerOnce)
+	{
+		EndTask();
+	}
+}
+
+void UAsyncAction_WaitVariableChange::OnEndStory(UInkpotStory* InStory)
+{
+	check(Inkpot);
+	Inkpot->EventOnStoryEnd.RemoveAll(this);
+	InStory->ClearVariableChange(this, VariableToListen);
+	CurrentStory = nullptr;
+}
+
+void UAsyncAction_WaitVariableChange::EndTask()
+{
+	check(Inkpot);
+	Inkpot->EventOnStoryBegin.RemoveAll(this);
+	Inkpot->EventOnStoryEnd.RemoveAll(this);
+	
+	if (CurrentStory && World)
+	{
+		// Story still in progress but user wats to force End this Task
+		// If we Clear Delegate Variable in the same tick while broadcasting all Delegates
+		// It will trigger ensure "Array has changed during ranged-for iteration!"
+		// We don't want to do that. So let do clean up next tick, just to be safe
+		World->GetTimerManager().SetTimerForNextTick([this]
+		{
+			CurrentStory->ClearVariableChange(this, VariableToListen);
+			CurrentStory = nullptr;
+		});
+	}
+	
+	SetReadyToDestroy();
+}

--- a/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
+++ b/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
@@ -63,10 +63,10 @@ void UAsyncAction_WaitVariableChange::EndTask()
 	
 	if (CurrentStory && World)
 	{
-		// Story still in progress but user wats to force End this Task
+		// Story still in progress but the user wants to force End this Task
 		// If we Clear Delegate Variable in the same tick while broadcasting all Delegates
-		// It will trigger ensure "Array has changed during ranged-for iteration!"
-		// We don't want to do that. So let do clean up next tick, just to be safe
+		// It will trigger to ensure "Array has changed during ranged-for iteration!"
+		// We don't want to do that. So let's do clean up next tick, just to be safe
 		World->GetTimerManager().SetTimerForNextTick([this]
 		{
 			CurrentStory->ClearVariableChange(this, VariableToListen);

--- a/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
+++ b/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
@@ -65,7 +65,7 @@ void UAsyncAction_WaitVariableChange::EndTask()
 	{
 		// Story still in progress but the user wants to force End this Task
 		// If we Clear Delegate Variable in the same tick while broadcasting all Delegates
-		// It will trigger to ensure "Array has changed during ranged-for iteration!"
+		// It will trigger ensure "Array has changed during ranged-for iteration!"
 		// We don't want to do that. So let's do clean up next tick, just to be safe
 		World->GetTimerManager().SetTimerForNextTick([this]
 		{

--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -259,27 +259,34 @@ void UInkpotStory::ObserveVariable( const FString& InVariable, TSharedPtr<FStory
 	StoryInternal->ObserveVariable( InVariable, InObserver );
 }
 
-void UInkpotStory::SetOnVariableChange( FOnVariableChange InDelegate, const FString &InVariable )
+void UInkpotStory::SetOnVariableChange( const FOnVariableChange& InDelegate, const FString &InVariable )
 {
 	TSharedPtr<FStoryVariableObserver> observer = MakeShared<FStoryVariableObserver>();
-	observer->BindLambda
+	observer->BindWeakLambda
 	(
-		[this, InDelegate](const FString& InVar, Ink::FValueType InType)
+		InDelegate.GetUObject(), [this, InDelegate] (const FString& InVar, Ink::FValueType InType)
 		{
-	        InDelegate.Execute( this, InVar, FInkpotValue(InType) );
+			InDelegate.Execute( this, InVar, FInkpotValue(InType) );
 		}
 	);
-	VariableObservers.Emplace( InVariable, observer );
+	
+	VariableObservers.AddUnique( InVariable, observer );
 	StoryInternal->ObserveVariable( InVariable, observer );
 }
 
-void UInkpotStory::ClearVariableChange( const FString &InVariable )
+void UInkpotStory::ClearVariableChange( const UObject* Owner, const FString &InVariable )
 {
-	if(!VariableObservers.Contains(InVariable))
+	if (!Owner || !VariableObservers.Contains(InVariable))
 		return;
-	TSharedPtr<FStoryVariableObserver> observer = VariableObservers[InVariable];
-	StoryInternal->RemoveVariableObserver( observer, InVariable );
-	VariableObservers.Remove( InVariable );
+	
+	for (auto Iterator = VariableObservers.CreateConstKeyIterator(InVariable); Iterator; ++Iterator)
+	{
+		if (Owner == Iterator->Value->GetUObject())
+		{
+			StoryInternal->RemoveVariableObserver( Iterator->Value, InVariable );
+			VariableObservers.RemoveSingle( InVariable, Iterator->Value );
+		}
+	}
 }
 
 void UInkpotStory::OnContinueInternal()

--- a/Source/Inkpot/Public/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.h
+++ b/Source/Inkpot/Public/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "AsyncAction_WaitVariableChange.generated.h"
+
+class UInkpot;
+class UInkpotStory;
+struct FInkpotValue;
+
+UCLASS(BlueprintType, Meta = (ExposedAsyncProxy = "AsyncTask"))
+class INKPOT_API UAsyncAction_WaitVariableChange : public UBlueprintAsyncActionBase
+{
+	GENERATED_BODY()
+
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FInkpotVariableChangeSignature, UInkpotStory*, Story, const FString&, Variable, const FInkpotValue&, Value);
+	
+public:
+	virtual void Activate() override;
+	
+	/**
+	* This Task will listen for any Variable changes in the current Active Story
+	* @param VariableToListen Name of the Variable to listen for changes
+	* @param bTriggerOnce This Task will be automatically terminated upon the first Variable Change
+	*/
+	UFUNCTION(BlueprintCallable, Meta = (WorldContext = "WorldContextObject", BlueprintInternalUseOnly = true, AutoCreateRefTerm = "VariableToListen"), Category = "Inkpot|Async Actions")
+	static UAsyncAction_WaitVariableChange* ListenForVariableChange(UObject* WorldContextObject, const FString& VariableToListen, const bool bTriggerOnce);
+
+	/**
+	* You must call this function manually when you want the AsyncTask to End
+	* For UMG Widgets, you would call it in the Widget's Destruct event
+	*/
+	UFUNCTION(BlueprintCallable, Category = "Inkpot|Async Actions")
+	void EndTask();
+
+	UPROPERTY(BlueprintAssignable, Transient, DuplicateTransient, DisplayName = "Variable Changed", Category = "Inkpot|Async Actions")
+	FInkpotVariableChangeSignature OnVariableChangeDelegate;
+
+private:
+	UFUNCTION()
+	void OnBeginStory(UInkpotStory* InStory);
+
+	UFUNCTION()
+	void OnEndStory(UInkpotStory* InStory);
+
+	UFUNCTION()
+	void OnVariableChange(UInkpotStory* InStory, const FString& InVariable, const FInkpotValue& NewValue);
+
+	UPROPERTY()
+	TObjectPtr<UWorld> World;
+
+	UPROPERTY()
+	TObjectPtr<UInkpotStory> CurrentStory;
+
+	UPROPERTY()
+	TObjectPtr<UInkpot> Inkpot;
+	
+	FString VariableToListen;
+
+	bool bTriggerOnce = false;
+};

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -108,10 +108,10 @@ public:
 	void SetEmpty( const FString& Variable );
 
 	UFUNCTION(BlueprintCallable, Category="Inkpot|Story")
-	void SetOnVariableChange( UPARAM(DisplayName="Event") FOnVariableChange Delegate, const FString &Variable );
+	void SetOnVariableChange( UPARAM(DisplayName="Event") const FOnVariableChange& Delegate, const FString &Variable );
 
-	UFUNCTION(BlueprintCallable, Category="Inkpot|Story")
-	void ClearVariableChange( const FString &Variable );
+	UFUNCTION(BlueprintCallable, Meta = (DefaultToSelf = "Owner", HidePin = "Owner"), Category="Inkpot|Story")
+	void ClearVariableChange( const UObject* Owner, const FString &Variable );
 
 	int32 GetVariableKeys( TArray<FString> &OutKeys );
 
@@ -141,8 +141,8 @@ private:
 
 protected:
 	TSharedPtr<FInkpotStoryInternal> StoryInternal;
-
-	TMap<FString, TSharedPtr<FStoryVariableObserver>> VariableObservers;
+	
+	TMultiMap<FString, TSharedPtr<FStoryVariableObserver>> VariableObservers;
 
 	UPROPERTY(BlueprintAssignable, Category="Inkpot|Story", meta=(DisplayName="OnContinue") )
 	FOnStoryContinue EventOnContinue; 
@@ -159,7 +159,6 @@ protected:
 private:
 	UPROPERTY(Transient)
 	TArray<UInkpotChoice*> Choices;
-
 };
 
 


### PR DESCRIPTION
Hi! Here are some PRs that I hope you'll find useful. You're free to modify/discard it to your will :)

1. Previously you couldn't have 2+ objects to listen for a similar Story Variable Change.  This PR extends this allowing multiple objects to listen for a single Story Variable.
2. Added WaitVariableChange Async Task as a replacement for InkpotWatch Component. WaitVariableChange will allow you to listen for Variable change even in Widgets or any other UObjects removing the need for Component.

Example screenshot:
![image](https://github.com/The-Chinese-Room/Inkpot/assets/34831419/1dcbb227-de5a-4758-9d78-10956dfd99e9)