### PR TITLE
Fixed an issue with ClearVariableChange function

### DIFF
--- a/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
+++ b/Source/Inkpot/Private/Inkpot/AsyncActions/AsyncAction_WaitVariableChange.cpp
@@ -57,10 +57,12 @@ void UAsyncAction_WaitVariableChange::OnEndStory(UInkpotStory* InStory)
 
 void UAsyncAction_WaitVariableChange::EndTask()
 {
-	check(Inkpot);
-	Inkpot->EventOnStoryBegin.RemoveAll(this);
-	Inkpot->EventOnStoryEnd.RemoveAll(this);
-	
+	if (IsValid(Inkpot))
+	{
+		Inkpot->EventOnStoryBegin.RemoveAll(this);
+		Inkpot->EventOnStoryEnd.RemoveAll(this);
+	}
+
 	if (CurrentStory && World)
 	{
 		// Story still in progress but the user wants to force End this Task

--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -161,7 +161,7 @@ FString UInkpotStory::GetCurrentFlowName()
 	return StoryInternal->GetCurrentFlowName();
 }
 
-void UInkpotStory::SwitchToDefautFlow()
+void UInkpotStory::SwitchToDefaultFlow()
 {
 	StoryInternal->SwitchToDefaultFlow();
 	UpdateChoices();

--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -308,19 +308,37 @@ void UInkpotStory::SetOnVariableChange( FOnInkpotVariableChange InDelegate, cons
 	StoryInternal->ObserveVariable( InVariable, observer );
 }
 
-void UInkpotStory::ClearVariableChange( const UObject* Owner, const FString &InVariable )
+bool UInkpotStory::ClearVariableChange( const UObject* Owner, const FString &Variable )
 {
-	if (!Owner || !VariableObservers.Contains(InVariable))
-		return;
+	if (!Owner || !VariableObservers.Contains(Variable))
+		return false;
+
+	bool bRemovedAtLeastOneEntry = false;
 	
-	for (auto Iterator = VariableObservers.CreateConstKeyIterator(InVariable); Iterator; ++Iterator)
+	for (auto Iterator = VariableObservers.CreateConstKeyIterator(Variable); Iterator; ++Iterator)
 	{
-		if (Owner == Iterator->Value->GetUObject())
+		if (Iterator->Value.IsValid() && Owner == Iterator->Value->GetUObject())
 		{
-			StoryInternal->RemoveVariableObserver( Iterator->Value, InVariable );
-			VariableObservers.RemoveSingle( InVariable, Iterator->Value );
+			StoryInternal->RemoveVariableObserver( Iterator->Value, Variable );
+			VariableObservers.RemoveSingle( Variable, Iterator->Value );
+			bRemovedAtLeastOneEntry = true;
 		}
 	}
+
+	return bRemovedAtLeastOneEntry;
+}
+
+void UInkpotStory::ClearAllVariableObservers( const FString& Variable )
+{
+	if (!VariableObservers.Contains(Variable))
+		return;
+	
+	for (auto Iterator = VariableObservers.CreateConstKeyIterator(Variable); Iterator; ++Iterator)
+	{
+		StoryInternal->RemoveVariableObserver( Iterator->Value, Variable );
+	}
+
+	VariableObservers.Remove(Variable);
 }
 
 void UInkpotStory::OnContinueInternal()

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -63,7 +63,7 @@ public:
 	FString GetCurrentFlowName();
 
 	UFUNCTION(BlueprintCallable, Category="Inkpot|Story")
-	void SwitchToDefautFlow();
+	void SwitchToDefaultFlow();
 
 	UFUNCTION(BlueprintPure, Category="Inkpot|Story")
 	bool IsFlowAlive( const FString &FlowName );

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -125,8 +125,12 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Inkpot|Story")
 	void SetOnVariableChange( UPARAM(DisplayName="Event") FOnInkpotVariableChange Delegate, const FString &Variable );
 
-	UFUNCTION(BlueprintCallable, Meta = (DefaultToSelf = "Owner", HidePin = "Owner"), Category="Inkpot|Story")
-	void ClearVariableChange( const UObject* Owner, const FString &Variable );
+	// @param Owner Object that initially called SetOnVariableChange
+	UFUNCTION(BlueprintCallable, Meta = (DefaultToSelf = "Owner", ExpandBoolAsExecs = "ReturnValue"), Category="Inkpot|Story")
+	bool ClearVariableChange( const UObject* Owner, const FString &Variable );
+	
+	UFUNCTION(BlueprintCallable, Category="Inkpot|Story")
+	void ClearAllVariableObservers( const FString &Variable );
 
 	UFUNCTION(BlueprintPure, Category = "Inkpot|Story")
 	TArray<FString> GetNamedContent();


### PR DESCRIPTION
Fixed an issue when calling `UInkpotStory::ClearVariableChange` from an object that is different from an object that initially called `UInkpotStory::SetOnVariableChange` will not clear it from `VariableObservers` Map. This was caused by `HidePin = "Owner"`.

Added `UInkpotStory::ClearAllVariableObservers` in case we want to clear all observers related to the Variable.

![Screenshot 2024-01-15 004843](https://github.com/The-Chinese-Room/Inkpot/assets/34831419/0621e3b5-b823-4698-aba9-db759ac5abd5)