### PR TITLE
Update discord link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This is version **1.03.21** of the plugin.</br>
 
 Inkpot is a wrapper for the wonderful narrative scripting language **Ink** developed by [Inkle Studios](https://www.inklestudios.com/ink/).<br>
 
-For general support and chat with other users, check out Inkle's discord <br>
-https://discord.gg/kshu8aYY<br>
+For general support and chat with other users, check out [Inkle's discord](https://discord.com/invite/inkle) <br>
 
 ### Changes in 1.03.21
 Added new abstract factory creation for stories, youclass UInkpotStory can now be subclassed on a per project basis.<br>


### PR DESCRIPTION
Previous link appears to be stale/invalid. I joined using the link I've swapped in.