### PR TITLE
Updated GetAssetRegistryTags to be consistent with the UObject header

### DIFF
--- a/Source/Inkpot/Private/Asset/InkpotStoryAsset.cpp
+++ b/Source/Inkpot/Private/Asset/InkpotStoryAsset.cpp
@@ -54,13 +54,13 @@ void UInkpotStoryAsset::PostInitProperties()
 #endif
 
 #if WITH_EDITOR
-void UInkpotStoryAsset::GetAssetRegistryTags( FAssetRegistryTagsContext InContext ) const
+void UInkpotStoryAsset::GetAssetRegistryTags(TArray<FAssetRegistryTag>& InContext) const
 {
 	if (AssetImportData)
 	{
-		InContext.AddTag( FAssetRegistryTag(SourceFileTagName(), AssetImportData->GetSourceData().ToJson(), FAssetRegistryTag::TT_Hidden) );
+		InContext.Add(FAssetRegistryTag(SourceFileTagName(), AssetImportData->GetSourceData().ToJson(), FAssetRegistryTag::TT_Hidden));
 	}
-	Super::GetAssetRegistryTags( InContext );
+	Super::GetAssetRegistryTags(InContext);
 }
 #endif
 

--- a/Source/Inkpot/Public/Asset/InkpotStoryAsset.h
+++ b/Source/Inkpot/Public/Asset/InkpotStoryAsset.h
@@ -20,7 +20,7 @@ public:
 
 #if WITH_EDITOR
 	virtual void PostInitProperties() override;
-	virtual void GetAssetRegistryTags( FAssetRegistryTagsContext InContext ) const override;
+	virtual void GetAssetRegistryTags(TArray<FAssetRegistryTag>& InContext) const override;
 #endif
 #if WITH_EDITORONLY_DATA
 	virtual void Serialize(FStructuredArchiveRecord Record) override;


### PR DESCRIPTION
I could not get inkpot to compile when added to our UE5.3 project. Upon investigation, I discovered that the GetAssetRegistryTags method, which InkpotStoryAsset inherits from UObject, has been changed and the method's signature no longer matches inkpot's source code. In order to fix this, I changed the method signature to match what I saw in AActor, which also overrides the method. Then it was a simple fix to change the AddTag call to simply Add the asset tag to the tag array which was provided. The project now compiles just fine, and I have been using it for several weeks now with no issues.