### PR TITLE
Fixes broken build on MacOS

### DIFF
--- a/Source/InkpotEditor/Private/Compiler/InkCompiler.cpp
+++ b/Source/InkpotEditor/Private/Compiler/InkCompiler.cpp
@@ -118,7 +118,7 @@ namespace InkCompiler
 	void ParseInklecateOutput(const FString& InklecateOutput, TArray<FString>& Errors, TArray<FString>& Warnings, bool& bCompileSuccess, bool& bExportSuccess)
 	{
 		FString toParse = TEXT("[") + InklecateOutput + TEXT("]");
-		toParse = toParse.Replace(_T("}"), _T("},"));
+		toParse = toParse.Replace(TEXT("}"), TEXT("},"));
 
 		TSharedRef< TJsonReader<> > Reader = TJsonReaderFactory<>::Create(toParse);
 

--- a/Source/InkpotEditor/Private/Test/InkFunctionTests.cpp
+++ b/Source/InkpotEditor/Private/Test/InkFunctionTests.cpp
@@ -4,7 +4,7 @@
 const FString UInkFunctionTests::FuncName_Message = TEXT("message");
 const FString UInkFunctionTests::FuncName_Multiply = TEXT("multiply");
 const FString UInkFunctionTests::FuncName_Times = TEXT("times");
-const FString UInkFunctionTests::FuncName_TRUE = TEXT("TRUE");
+const FString UInkFunctionTests::FuncName_BoolTrue = TEXT("TRUE");
 
 FInkpotValue UInkFunctionTests::Message(const TArray<FInkpotValue> & InValues)
 {
@@ -30,7 +30,7 @@ FInkpotValue UInkFunctionTests::Times(const TArray<FInkpotValue> & InValues)
 	return UInkpotValueLibrary::MakeStringInkpotValue( output );
 }
 
-FInkpotValue UInkFunctionTests::TRUE(const TArray<FInkpotValue> & InValues)
+FInkpotValue UInkFunctionTests::BoolTrue(const TArray<FInkpotValue>& InValues)
 {
 	return UInkpotValueLibrary::MakeBoolInkpotValue( true );
 }

--- a/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
+++ b/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
@@ -1150,9 +1150,9 @@ bool FInkTests::RunTest(const FString& InkTestName)
 								{
 									function->BindDynamic( testFunctions, &UInkFunctionTests::Times );
 								}
-								else if(functionName.Equals(UInkFunctionTests::FuncName_TRUE))
+								else if(functionName.Equals(UInkFunctionTests::FuncName_BoolTrue))
 								{
-									function->BindDynamic( testFunctions, &UInkFunctionTests::TRUE );
+									function->BindDynamic(testFunctions, &UInkFunctionTests::BoolTrue);
 								}
 								else
 								{

--- a/Source/InkpotEditor/Public/Test/InkFunctionTests.h
+++ b/Source/InkpotEditor/Public/Test/InkFunctionTests.h
@@ -24,7 +24,7 @@ public:
 	static const FString FuncName_Times;
 
 	UFUNCTION()
-	FInkpotValue TRUE(const TArray<FInkpotValue> & InValues);
-	static const FString FuncName_TRUE;
+	FInkpotValue BoolTrue(const TArray<FInkpotValue>& InValues);
+	static const FString FuncName_BoolTrue;
 };
 


### PR DESCRIPTION
I couldn't get this to build in UE 5.5.4 on Mac because of a couple small issues.

First, `_T(...)` needed to be replaced with `TEXT(...)` in `InkCompiler` because the Mac compiler didn't understand it.
Also, the name `TRUE` in the `Test/` directory caused a redefinition error, so I renamed it to `BoolTrue`.

Making these changes fixes the build and the plugin works great on Mac.