### PR TITLE
Fix ContinueMaximallyAtMath typo

### DIFF
--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -52,7 +52,7 @@ public:
 	FString ContinueMaximally();
 
 	/**
-	 * ContinueMaximallyAtMath
+	 * ContinueMaximallyAtPath
 	 * Executes story script until choice or no more content, from a specified point in the story.
 	 *
 	 * @param Path - The knot and\or the stitch to start the story at, 


### PR DESCRIPTION
Though I suppose in a cosmic sense, all computer programs continue maximally at math.