### PR TITLE
fix(): update UObject* usage for UE 5.6 compatibility

### DIFF
--- a/Source/Inkpot/Private/Inkpot/InkpotStories.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStories.cpp
@@ -121,7 +121,7 @@ UInkpotStory* UInkpotStories::Reload( UInkpotStoryAsset* InInkpotStoryAsset )
 		return nullptr;
 	int32 handle = *keyptr;
 
-	UInkpotStory **storyInProgressPtr = Stories.Find( handle );
+	TObjectPtr<UInkpotStory>* storyInProgressPtr = Stories.Find( handle );
 	if(!storyInProgressPtr)
 		return nullptr;
 
@@ -129,7 +129,7 @@ UInkpotStory* UInkpotStories::Reload( UInkpotStoryAsset* InInkpotStoryAsset )
 	if(!storyInternal->IsValidStory())
 		return nullptr;
 
-	UInkpotStory *story = *storyInProgressPtr;
+	UInkpotStory *story = storyInProgressPtr->Get();
 	story->ResetContent( storyInternal );
 	return story;
 }
@@ -140,9 +140,9 @@ void UInkpotStories::Replay( UInkpotStory* InStory, bool bInResetState )
 		return;
 
 	int index = InStory->GetID();
-	UInkpotStoryHistory **history = StoryHistories.Find( index );
+	TObjectPtr<UInkpotStoryHistory>* history = StoryHistories.Find( index );
 	if(!history)
 		return;
 
-	(*history)->Replay( bInResetState );
+	history->Get()->Replay( bInResetState );
 }

--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -443,7 +443,7 @@ void UInkpotStory::OnMakeChoiceInternal(TSharedPtr<Ink::FChoice> InChoice)
 	if(!EventOnContinue.IsBound())
 		return;
 	int32 key = InChoice->GetIndex();
-	UInkpotChoice ** choicePtr = Choices.FindByPredicate( [key]( UInkpotChoice *pChoice ) { return *pChoice == key; } );
+	TObjectPtr<UInkpotChoice>* choicePtr = Choices.FindByPredicate([key](TObjectPtr<UInkpotChoice> pChoice) { return *pChoice == key; });
 	if(!choicePtr)
 		return;
 	DumpDebug( *choicePtr );

--- a/Source/Inkpot/Public/Asset/InkpotStoryAsset.h
+++ b/Source/Inkpot/Public/Asset/InkpotStoryAsset.h
@@ -37,6 +37,6 @@ private:
 
 #if WITH_EDITORONLY_DATA
 	UPROPERTY(VisibleAnywhere, Instanced, Category = ImportSettings)
-	class UAssetImportData* AssetImportData;
+	TObjectPtr<class UAssetImportData> AssetImportData;
 #endif
 };

--- a/Source/Inkpot/Public/Inkpot/Inkpot.h
+++ b/Source/Inkpot/Public/Inkpot/Inkpot.h
@@ -75,7 +75,7 @@ private:
 
 private:
 	UPROPERTY()
-	UInkpotStories *Stories;
+	TObjectPtr<UInkpotStories> Stories;
 
 	UPROPERTY()
 	TWeakObjectPtr<UGameInstance> GameInstance{ nullptr };

--- a/Source/Inkpot/Public/Inkpot/InkpotStories.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStories.h
@@ -37,14 +37,14 @@ private:
 	int32 NextStoryHandle{0};
 
 	UPROPERTY(Transient)
-	TMap<int32, UInkpotStory*> Stories;
+	TMap<int32, TObjectPtr<UInkpotStory>> Stories;
 
 	UPROPERTY(Transient)
-	TMap<int32, UInkpotStoryAsset*> StoryAssets;
+	TMap<int32, TObjectPtr<UInkpotStoryAsset>> StoryAssets;
 
 	UPROPERTY(Transient)
-	TMap<int32, UInkpotStoryHistory*> StoryHistories;
+	TMap<int32, TObjectPtr<UInkpotStoryHistory>> StoryHistories;
 
 	UPROPERTY(Transient)
-	UInkpotStoryFactoryBase *StoryFactory;
+	TObjectPtr<UInkpotStoryFactoryBase> StoryFactory;
 };

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -640,7 +640,7 @@ protected:
 
 private:
 	UPROPERTY(Transient)
-	TArray<UInkpotChoice*> Choices;
+	TArray<TObjectPtr<UInkpotChoice>> Choices;
 
 	UPROPERTY(Transient)
 	bool bIsInFunctionEvaluation{ false };

--- a/Source/Inkpot/Public/Inkpot/InkpotStoryFactory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStoryFactory.h
@@ -24,7 +24,7 @@ public:
 
 protected:
 	UPROPERTY()
-	UInkpotStory* ABadStory;
+	TObjectPtr<UInkpotStory> ABadStory;
 };
 
 

--- a/Source/InkpotEditor/Public/Blotter/BlotterUIEntryVariable.h
+++ b/Source/InkpotEditor/Public/Blotter/BlotterUIEntryVariable.h
@@ -25,7 +25,7 @@ public:
 
 protected:
 	UPROPERTY(Transient, BluePrintReadOnly )
-	UBlotterVariable* BlotterVariable;
+	TObjectPtr<UBlotterVariable> BlotterVariable;
 };
 
 

--- a/Source/InkpotEditor/Public/Blotter/BlotterVariable.h
+++ b/Source/InkpotEditor/Public/Blotter/BlotterVariable.h
@@ -101,7 +101,7 @@ protected:
 
 private:
 	UPROPERTY(Transient)
-	UInkpotStory* Story;
+	TObjectPtr<UInkpotStory> Story;
 
 	UPROPERTY(Transient)
 	FText	Name;
@@ -122,5 +122,5 @@ private:
 	bool bOptionsOpen {false};
 
 	UPROPERTY(Transient)
-	UBlotterUIEntryVariable *DisplayWidget {nullptr};
+	TObjectPtr<UBlotterUIEntryVariable> DisplayWidget {nullptr};
 };


### PR DESCRIPTION
This pull request updates all relevant pointer member declarations in the Inkpot plugin from raw `UObject*` to `TObjectPtr<UObject>` where required by Unreal Engine 5.6's header tool constraints.

Changes include:
- Minimal, formatting-preserving conversions of `UObject*` members in `.h` files
- Matching updates in `InkpotStory.cpp` and `InkpotStories.cpp` to fix implicit type mismatches with `TObjectPtr`
- All changes verified to compile successfully in UE 5.6

No changes in logic or behavior — only pointer types have been adjusted.

So far, no In-Editor-Testing has been done.