### PR TITLE
Adds MapCurrentTagsWithDelimiter

### DIFF
--- a/Source/Inkpot/Private/Inkpot/InkpotLibrary.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotLibrary.cpp
@@ -26,6 +26,28 @@ FString UInkpotLibrary::GetTagWithPrefixAndStrip(UInkpotStory* InStory, const FS
 	return rval;
 }
 
+TMap<FName, FString> UInkpotLibrary::MapCurrentTagsWithDelimiter(UInkpotStory* InStory, const FString& InTagDelimiter = ": ")
+{
+	TMap<FName, FString> rval;
+	if (IsValid(InStory))
+	{
+		const TArray<FString>& tags = InStory->GetCurrentTags();
+		for (const FString& tag : tags)
+		{
+			FString LeftKey, RightVal;
+			if (tag.Split(InTagDelimiter, &LeftKey, &RightVal))
+			{
+				rval.Add(*LeftKey, *RightVal);
+			}
+		}
+	}
+	else
+	{
+		INKPOT_ERROR("Story is not set");
+	}
+	return rval;
+}
+
 UAssetUserData* UInkpotLibrary::GetStoryAssetUserData(UInkpotStory* InStory, TSubclassOf<UAssetUserData> InClass)
 {
 	if (!IsValid(InStory))

--- a/Source/Inkpot/Public/Inkpot/InkpotLibrary.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotLibrary.h
@@ -26,6 +26,21 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Inkpot|Story")
 	static INKPOT_API FString GetTagWithPrefixAndStrip(UInkpotStory *Story, const FString& TagPrefix);
 
+
+	/**
+	 * MapCurrentTagsWithDelimiter
+	 * gets tags containing the delimiter from the current list of tags.
+	 * if tags with the delimiter are found, returns them as a map, with the left  side
+	 * of the delimiter as the key and the right side as the value.
+	 *
+	 * @param Story - The story to query.
+	 * @param TagDelimiter - The delimiter to split on. Default is ": ".
+	 * @returns A map of key:value pairs assembled from ink tags containing the delimiter.
+	 */
+	UFUNCTION(BlueprintPure, Category = "Inkpot|Story")
+	static INKPOT_API TMap<FName, FString> MapCurrentTagsWithDelimiter(UInkpotStory* Story, const FString& TagDelimiter);
+
+
 	/* GetStoryAssetUserData
 	* Get the asset user data instance (of class) from the story data asset used to create the story
 	*/


### PR DESCRIPTION
Adds a pure function that pulls in the current tags and returns a map wherein all current tags containing the delimiter will be stored with the left side of the delimiter as keys and the right side as values.