### PR TITLE
Get knot from path

### DIFF
--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -342,6 +342,27 @@ int32 UInkpotStory::GetAliveFlowCount()
 	return count; 
 }
 
+FGameplayTag UInkpotStory::GetKnotFromPathGT(const FGameplayTag InPath, bool& OutHasParentKnot)
+{
+	TArray< FGameplayTag > ParentTags;
+	InPath.ParseParentTags(ParentTags);
+	int32 ParentCount = ParentTags.Num();
+
+	if (ParentCount < 2)
+	{
+		INKPOT_ERROR("'%s' is not a knot or stitch", *InPath.ToString());
+		OutHasParentKnot = false;
+		return InPath;
+	}
+	else if (ParentCount == 2)
+	{
+		OutHasParentKnot = false;
+		return InPath;
+	}
+	OutHasParentKnot = true;
+	return InPath.RequestDirectParent();
+}
+
 void UInkpotStory::SetValue(const FString &InVariable, FInkpotValue InValue, bool &OutSuccess )
 {
 	TSharedPtr<Ink::FVariableState> variableState = StoryInternal->GetVariablesState();

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -335,6 +335,17 @@ public:
 	int VisitCountAtPathStringGT( FGameplayTag Path );
 
 	/**
+	 * GetKnotFromPathGT
+	 * If passed a stitch or knot tag, it will return the knot tag.
+	 *
+	 * @param Path - Ink.Path GameplayTag from which to retrieve parent
+	 * @param HasParentKnot - returns True if the parent GameplayTag is a knot.
+	 * @returns GameplayTag of Knot, or returns Path if parent isn't a knot.
+	 */
+	UFUNCTION(BlueprintPure, Category = "Inkpot|Story", meta = (Categories = "Ink.Path"))
+	FGameplayTag GetKnotFromPathGT(const FGameplayTag Path, bool& HasParentKnot);
+
+	/**
 	 * SetValue
 	 * Sets the value of a variable in the story.
 	 *


### PR DESCRIPTION
New function that returns the Gameplay Tag of a knot when passed a Path Gameplay Tag (a knot or stitch). Useful when stitches need to inherit the knot's ink tags, or when different knots require different handling (such as different UI surfaces).

I didn't create a string equivalent because parsing a path string is no harder to do in Blueprints than in c++, but with Gameplay Tags, the GameplayTag functions necessary to retrieve the parent knot are not exposed to Blueprints.