### PR TITLE
Get GT From String

### DIFF
--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -68,6 +68,34 @@ TArray<FString> UInkpotStory::TagsForContentAtPathGT(FGameplayTag InPath )
 	return TagsForContentAtPath( UInkpotGameplayTagLibrary::PathTagToString(InPath) );
 }
 
+FGameplayTag UInkpotStory::GetGTFromString(const FString InTagString, const EInkGameplayTagTypes TagType, bool& FoundTag)
+{
+	FString TagString;
+	switch(TagType)
+	{
+	case EInkGameplayTagTypes::INK_ORIGIN:
+		TagString = INK_ORIGIN_GAMEPLAYTAG_PREFIX + InTagString;
+		break;
+	case EInkGameplayTagTypes::INK_PATH:
+		TagString = INK_PATH_GAMEPLAYTAG_PREFIX + InTagString;
+		break;
+	case EInkGameplayTagTypes::INK_VAR:
+		TagString = INK_VARIABLE_GAMEPLAYTAG_PREFIX + InTagString;
+		break;
+	}
+	FName TagName = FName(*TagString);
+	FGameplayTag OutTag = UGameplayTagsManager::Get().RequestGameplayTag(TagName, false);
+	if (OutTag.IsValid())
+	{
+		FoundTag = true;
+	}
+	else
+	{
+		FoundTag = false;
+	}
+	return OutTag;
+}
+
 void UInkpotStory::ChoosePath( const FString &InPath )
 {
 	ChoosePathInternal(InPath);

--- a/Source/Inkpot/Public/Inkpot/InkpotGameplayTagLibrary.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotGameplayTagLibrary.h
@@ -15,6 +15,14 @@
 //#define INK_PATH_GAMEPLAYTAG_FILTER "Ink.Path"
 //#define INK_VARIABLE_GAMEPLAYTAG_FILTER "Ink.Variable"
 
+UENUM(BlueprintType)
+enum class EInkGameplayTagTypes : uint8
+{
+	INK_ORIGIN	UMETA(DisplayName = "Origin"),
+	INK_PATH	UMETA(DisplayName = "Path"),
+	INK_VAR		UMETA(DisplayName = "Variable")
+};
+
 UCLASS(meta=(ScriptName="InkpotGameplayTagLibrary"), MinimalAPI)
 class UInkpotGameplayTagLibrary : public UBlueprintFunctionLibrary
 {

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -276,6 +276,20 @@ public:
 	TArray<FString> TagsForContentAtPathGT( FGameplayTag Path );
 
 	/**
+	 * GetGTFromString
+	 * Gets the GameplayTag matching the supplied string and type, if a match exists.
+	 * Warning: slow and can introduce bugs.
+	 *
+	 * @param TagString - The tag string to search for, such as Knot.Stitch or Inventory.Apple.
+	 *						Don't include Ink.Origin, Ink.Path, or Ink.Variable.
+	 * @param TagType - The type of Ink tag: Origin, Path, or Variable.
+	 * @param FoundTag - Returns true if a tag was found; otherwise false.
+	 * @returns A GameplayTag if the string matches an existing tag, or an empty/invalid tag.
+	 */
+	UFUNCTION(BlueprintPure, Category = "Inkpot|Story")
+	FGameplayTag GetGTFromString(const FString TagString, const EInkGameplayTagTypes TagType, bool &FoundTag);
+
+	/**
 	 * ChoosePath
 	 * Choose a new point of execution for the current flow.
 	 *


### PR DESCRIPTION
Uses RequestGameplayTag() to get a Gameplay Tag from a string.

I added the enum to specify the top two levels of the hierarchy in order to future-proof a bit: if Ink's tag architecture needs to change in the future, updating the `*_GAMEPLAYTAG_PREFIX`s will maintain compatibility for projects using this function.

Setting Gameplay Tags from strings is not preferred due to speed and risk of typos, but this allows for specifying Gameplay Tags in Ink tags. This can be useful if you're using Gameplay Tags in a project and need to use Ink tags to refer to list origins, variables, or paths.

In my case I have items stored in stitches (such as books with readable pages), but they can also be picked up and added to inventory, so I need to specify the list origin. The Ink docs also mention the use of tags to specify what items should be present in a room in Heaven's Vault. All of this is possible without involving GameplayTags, but GameplayTags still retain their advantages (such as ease of querying) once set.

In any case I'm about 80/20 on this being a good idea, and leave it to you to decide whether to merge it.