### PR TITLE
Block continue while rendering

### DIFF
--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -732,7 +732,7 @@ void UInkpotStory::DumpContainer(const FString &InName, TSharedPtr<Ink::FContain
 		if( container )
 		{
 			containersDumped.Add(container);
-			FString name = container->GetName();
+			FString name = container->GetPath()->ToString();
 			if (name.IsEmpty())
 				name = "inline";
 			DumpContainer(name, container, Indent + 1 );
@@ -784,6 +784,55 @@ void UInkpotStory::DumpContentAtKnot( const FString& InName )
 		return;
 	}
 	DumpContainer(InName, knotContainer  );
+}
+
+void UInkpotStory::DumpMainContentPaths()
+{
+	TSharedPtr<Ink::FContainer> main = StoryInternal->GetMainContentContainer();
+	DumpContainerPaths("<root>", main);
+}
+
+void UInkpotStory::DumpContainerPaths(const FString& InName, TSharedPtr<Ink::FContainer> InContainer, int Indent)
+{
+	if (!InContainer)
+		return;
+
+	FString pad;
+	for (int i = 0; i < Indent; ++i)
+		pad += '\t';
+
+	INKPOT_LOG("%s%s", *pad, *InName);
+	TArray<TSharedPtr<Ink::FObject>>* contents = InContainer->GetContent().Get();
+	TSet<TSharedPtr<Ink::FContainer>> containersDumped;
+
+	for (TSharedPtr<Ink::FObject> obj : *contents)
+	{
+		TSharedPtr<Ink::FContainer> container = Ink::FObject::DynamicCastTo<Ink::FContainer>(obj);
+		if (container)
+		{
+			containersDumped.Add(container);
+			FString nameAlso = InContainer->GetPath()->ToString();
+			static volatile bool breakMe = false;
+			if (container->GetName().Equals(TEXT("Intro")))
+				breakMe = true;
+
+			FString name = container->GetPath()->ToString();
+			if (name.IsEmpty())
+				name = "inline";
+			DumpContainerPaths(name, container, Indent + 1);
+		}
+	}
+
+	TSharedPtr<TMap<FString, TSharedPtr<Ink::FObject>>> namedContentPtr = InContainer->GetNamedContent();
+	for (auto pair : *namedContentPtr)
+	{
+		TSharedPtr<Ink::FContainer> container = Ink::FObject::DynamicCastTo<Ink::FContainer>(pair.Value);
+		if (!container)
+			continue;
+		if (containersDumped.Contains(container))
+			continue;
+		DumpContainerPaths(pair.Key, container, Indent + 1);
+	}
 }
 
 void UInkpotStory::GatherAllStrings( TMap<FString, FString> &OutStrings )

--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -180,6 +180,11 @@ FString UInkpotStory::ContinueIfYouCan(bool& Continued)
 
 FString UInkpotStory::ContinueInternal()
 {
+	if (IsLineRenderingForFlow(GetCurrentFlowName()))
+	{
+		INKPOT_WARN("Continue ignored while a line is rendering for flow '%s'", *GetCurrentFlowName());
+		return GetCurrentText();
+	}
 	return StoryInternal->Continue();
 }
 
@@ -190,6 +195,11 @@ FString UInkpotStory::ContinueMaximally()
 
 FString UInkpotStory::ContinueMaximallyInternal()
 {
+	if (IsLineRenderingForFlow(GetCurrentFlowName()))
+	{
+		INKPOT_WARN("ContinueMaximally ignored while a line is rendering for flow '%s'", *GetCurrentFlowName());
+		return GetCurrentText();
+	}
 	return StoryInternal->ContinueMaximally();
 }
 
@@ -214,6 +224,8 @@ bool UInkpotStory::CanContinue()
 
 bool UInkpotStory::CanContinueInternal()
 {
+	if (IsLineRenderingForFlow(GetCurrentFlowName()))
+		return false;
 	return StoryInternal->CanContinue();
 }
 
@@ -573,9 +585,20 @@ void UInkpotStory::OnContinueInternal()
 	{
 		UpdateChoices();
 		DumpDebug();
-		if (!EventOnContinue.IsBound())
-			return;
-		EventOnContinue.Broadcast(this);
+
+		if (EventOnContinue.IsBound())
+			EventOnContinue.Broadcast(this);
+
+		// Natural completion: the current flow has run out of content and has no
+		// choices. Reported per flow so listeners can tear down without polling.
+		// Uses the raw VM state rather than CanContinue()/HasChoices() because those
+		// are gated by line rendering.
+		// Deferred until the last line of the flow has finished rendering, so the
+		// event arrives after the final line is presented, not while it is in flight.
+		if (!StoryInternal->CanContinue() && !StoryInternal->HasChoices())
+		{
+			NotifyFlowEndedOrDefer(GetCurrentFlowName());
+		}
 	}
 	DebugRefresh();
 }
@@ -1004,6 +1027,27 @@ FOnStoryLoadJSON& UInkpotStory::OnStoryLoadJSON()
 	return EventOnStoryLoadJSON;
 }
 
+FOnFlowEnded& UInkpotStory::OnFlowEnded()
+{
+	return EventOnFlowEnded;
+}
+
+void UInkpotStory::NotifyFlowEndedOrDefer(const FString& InFlowName)
+{
+	// If a line is still rendering for this flow, wait for NotifyLineRenderEnd to fire
+	// the event so it arrives after the final line is presented.
+	if (IsLineRenderingForFlow(InFlowName))
+		FlowsPendingEnd.Add(InFlowName);
+	else
+		BroadcastFlowEnded(InFlowName);
+}
+
+void UInkpotStory::BroadcastFlowEnded(const FString& InFlowName)
+{
+	if (EventOnFlowEnded.IsBound())
+		EventOnFlowEnded.Broadcast(this, InFlowName);
+}
+
 UInkpotLine *UInkpotStory::GetCurrentLine()
 {
 	UInkpotLine* line = NewObject<UInkpotLine>( this );
@@ -1110,24 +1154,45 @@ FOnStoryContinue& UInkpotStory::OnDebugRefresh()
 
 void UInkpotStory::NotifyLineRenderBegin(FName InContext)
 {
-	LineRenderContextsInFlight.Add( InContext );
+	// Record the flow that owns this render so the gate can be scoped per flow.
+	LineRenderContextsInFlight.Add( InContext, GetCurrentFlowName() );
 }
 
 void UInkpotStory::NotifyLineRenderEnd(FName InContext, bool bInSuccess)
 {
-	if (!LineRenderContextsInFlight.Contains(InContext))
+	const FString* OwnerFlow = LineRenderContextsInFlight.Find(InContext);
+	if (!OwnerFlow)
 	{
 		INKPOT_ERROR("Could not find context for end of line render. '%s'", *InContext.ToString() );
 		return;
 	}
 
+	FString Flow = *OwnerFlow;
 	LineRenderContextsInFlight.Remove(InContext);
 
 	if (EventOnLineComplete.IsBound())
 		EventOnLineComplete.Broadcast(this, InContext, bInSuccess);
+
+	// If this flow was waiting to report its end until rendering finished, and this was
+	// the last render in flight for it, fire OnFlowEnded now.
+	if (FlowsPendingEnd.Contains(Flow) && !IsLineRenderingForFlow(Flow))
+	{
+		FlowsPendingEnd.Remove(Flow);
+		BroadcastFlowEnded(Flow);
+	}
 }
 
 bool UInkpotStory::IsLineRendering() const
 {
 	return LineRenderContextsInFlight.Num() > 0;
+}
+
+bool UInkpotStory::IsLineRenderingForFlow(const FString& InFlowName) const
+{
+	for (const TPair<FName, FString>& Context : LineRenderContextsInFlight)
+	{
+		if (Context.Value == InFlowName)
+			return true;
+	}
+	return false;
 }

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -867,6 +867,13 @@ public:
 	virtual void DumpMainContent();
 
 	/**
+	 * DumpMainContentPaths
+	 * Writes all container paths for story to debug log.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Inkpot|Story")
+	virtual void DumpMainContentPaths();
+
+	/**
 	 * DumpContentAtPath
 	 * Writes all Ink opcodes for content at specified Knot & Stitch to debug log. 
 	 */
@@ -881,6 +888,7 @@ public:
 	void DumpContentAtKnot( const FString& InName );
 
 	void DumpContainer(const FString& InName, TSharedPtr<Ink::FContainer> InContainer, int Indent = 0);
+	void DumpContainerPaths(const FString& InName, TSharedPtr<Ink::FContainer> InContainer, int Indent = 0);
 
 	TSharedPtr<Ink::FListDefinition> GetListOrigin(const FString& InOriginName, const FString& InItemName);
 

--- a/Source/Inkpot/Public/Inkpot/InkpotStory.h
+++ b/Source/Inkpot/Public/Inkpot/InkpotStory.h
@@ -17,6 +17,7 @@ DECLARE_DYNAMIC_DELEGATE_ThreeParams(FOnInkpotVariableChange, UInkpotStory*, Sto
 DECLARE_DYNAMIC_DELEGATE_RetVal_OneParam(FInkpotValue, FInkpotExternalFunction, const TArray<FInkpotValue> & , Values );
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnStoryLoadJSON, UInkpotStory*, Story );
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams( FOnLineComplete, UInkpotStory*, Story, const FName&, Context, bool, bSuccess );
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams( FOnFlowEnded, UInkpotStory*, Story, const FString&, FlowName );
 
 // macro for binding functions in your derived story classes
 #define BindInkFunction( NameInk, NameCPP ) \
@@ -793,6 +794,15 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Inkpot|Story")
 	bool IsLineRendering() const;
 
+	/**
+	 * IsLineRenderingForFlow
+	 * returns whether a line is still rendering for the named flow specifically.
+	 * Used to gate Continue / CanContinue per flow so concurrent flows do not block
+	 * one another.
+	 */
+	UFUNCTION(BlueprintPure, Category = "Inkpot|Story")
+	bool IsLineRenderingForFlow(const FString& FlowName) const;
+
 	
 	/**
 	 * ToJSON
@@ -824,11 +834,12 @@ public:
 
 	void ObserveVariable( const FString& Variable, TSharedPtr<FStoryVariableObserver> Observer );
 
-	FOnStoryContinue& OnContinue(); 
-	FOnMakeChoice& OnMakeChoice(); 
-	FOnChoosePath& OnChoosePath(); 
-	FOnSwitchFlow& OnSwitchFlow(); 
-	FOnStoryLoadJSON& OnStoryLoadJSON(); 
+	FOnStoryContinue& OnContinue();
+	FOnMakeChoice& OnMakeChoice();
+	FOnChoosePath& OnChoosePath();
+	FOnSwitchFlow& OnSwitchFlow();
+	FOnStoryLoadJSON& OnStoryLoadJSON();
+	FOnFlowEnded& OnFlowEnded();
 
 #if WITH_EDITOR 
 	FOnStoryContinue& OnDebugRefresh();
@@ -907,6 +918,11 @@ protected:
 	void BroadcastFlowChange();
 	void UpdateChoices();
 
+	// Fires EventOnFlowEnded for a flow, or defers it until the flow's last in-flight
+	// line render ends if one is still in progress.
+	void NotifyFlowEndedOrDefer(const FString& FlowName);
+	void BroadcastFlowEnded(const FString& FlowName);
+
 	void DumpDebug(UInkpotChoice *Choice);
 	
 	TArray<FString> GetNamedContent( TSharedPtr<Ink::FContainer> Container );
@@ -946,6 +962,10 @@ protected:
 	UPROPERTY(BlueprintAssignable, Category = "Inkpot|Story", meta = (DisplayName = "OnLineComplete"))
 	FOnLineComplete EventOnLineComplete;
 
+	// Fired (per flow) when the current flow runs out of content and has no choices.
+	UPROPERTY(BlueprintAssignable, Category = "Inkpot|Story", meta = (DisplayName = "OnFlowEnded"))
+	FOnFlowEnded EventOnFlowEnded;
+
 #if WITH_EDITORONLY_DATA 
 	UPROPERTY(BlueprintAssignable, Category = "Inkpot|Story", meta = (DisplayName = "OnDebugRefresh"))
 	FOnStoryContinue EventOnDebugRefresh;
@@ -958,8 +978,14 @@ private:
 	UPROPERTY(Transient)
 	bool bIsInFunctionEvaluation{ false };
 
+	// In-flight line-render contexts mapped to the flow that owned them at begin time.
+	// Lets the render gate be scoped per flow.
 	UPROPERTY(Transient)
-	TSet<FName> LineRenderContextsInFlight;
+	TMap<FName, FString> LineRenderContextsInFlight;
+
+	// Flows that became exhausted (no content, no choices) while a line was still
+	// rendering. OnFlowEnded for these is deferred until the flow's last render ends.
+	TSet<FString> FlowsPendingEnd;
 };
 
 


### PR DESCRIPTION
* Fix - Continue() wasn't blocked when renderers were still using the line.
* Extended the renderer blocking to work per-flow rather than across all flows, so multiple conversations could be in-flight at the same time.
* Also added an event - OnFlowEnded, to call back when all content and choices had run out for a flow; allows rendering systems to shut down whatever they were doing and clean up.
