### PR TITLE
Fix UE 5.8 build: FJsonObject keys are now FSharedString

### DIFF
--- a/Source/InkPlusPlus/Private/Ink/Flow.cpp
+++ b/Source/InkPlusPlus/Private/Ink/Flow.cpp
@@ -40,7 +40,7 @@ Ink::FFlow::FFlow(const FString& InName, Ink::FStory* InStory, const TSharedPtr<
 	// Choice Threads is optional
 	const TSharedPtr<FJsonObject>* jsonChoiceThreadsObject;
 	if (InJSONObject->TryGetObjectField(TEXT("choiceThreads"), jsonChoiceThreadsObject))
-		LoadFlowChoiceThreads(jsonChoiceThreadsObject->Get()->Values, *InStory);
+		LoadFlowChoiceThreads(*jsonChoiceThreadsObject->Get(), *InStory);
 }
 
 
@@ -91,7 +91,7 @@ void Ink::FFlow::WriteJSON(TJsonWriter<>* InJSONWriter)
 	InJSONWriter->WriteObjectEnd();
 }
 
-void Ink::FFlow::LoadFlowChoiceThreads(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONChoiceThreads, const Ink::FStory& InStory)
+void Ink::FFlow::LoadFlowChoiceThreads(const FJsonObject& InJSONChoiceThreads, const Ink::FStory& InStory)
 {
 	for (const TSharedPtr<Ink::FChoice>& choice : *CurrentChoices)
 	{
@@ -102,9 +102,8 @@ void Ink::FFlow::LoadFlowChoiceThreads(const TMap<FString, TSharedPtr<FJsonValue
 		}
 		else
 		{
-			const TSharedPtr<FJsonValue> jsonSavedChoiceThread = InJSONChoiceThreads[FString::FromInt(choice->GetOriginalThreadIndex())];
 			const TSharedPtr<FJsonObject>* jsonSavedChoiceThreadObject;
-			if (!jsonSavedChoiceThread->TryGetObject(jsonSavedChoiceThreadObject))
+			if (!InJSONChoiceThreads.TryGetObjectField(FString::FromInt(choice->GetOriginalThreadIndex()), jsonSavedChoiceThreadObject))
 			{
 				UE_LOG(InkPlusPlus, Error, TEXT("Flow : cannot get JSON Saved Choice Thread object from JSON Saved Choice Thread Value!"))
 				return;

--- a/Source/InkPlusPlus/Private/Ink/JsonExtension.cpp
+++ b/Source/InkPlusPlus/Private/Ink/JsonExtension.cpp
@@ -18,16 +18,15 @@ TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonExtension::JSONObjectToInkObje
 	return convertedMap;
 }
 
-TMap<FString, int32> Ink::FJsonExtension::JSONObjectToIntDictionary(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONObject)
+TMap<FString, int32> Ink::FJsonExtension::JSONObjectToIntDictionary(const FJsonObject& InJSONObject)
 {
 	TMap<FString, int32> convertedMap;
-	convertedMap.Reserve(InJSONObject.Num());
+	convertedMap.Reserve(InJSONObject.Values.Num());
 
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& jsonPair : InJSONObject)
+	for (const auto& jsonPair : InJSONObject.Values)
 	{
-		const FString& key = jsonPair.Key;
 		int32 value = static_cast<int32>(jsonPair.Value->AsNumber());
-		convertedMap.Add(jsonPair.Key, value);
+		convertedMap.Add(FString(*jsonPair.Key), value);
 	}
 
 	return convertedMap;

--- a/Source/InkPlusPlus/Private/Ink/JsonSerialisation.cpp
+++ b/Source/InkPlusPlus/Private/Ink/JsonSerialisation.cpp
@@ -108,13 +108,11 @@ TSharedPtr<TArray<TSharedPtr<Ink::FChoice>>> Ink::FJsonSerialisation::JsonArrayT
 TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonSerialisation::JsonObjectToDictionaryRuntimeObjects(const FJsonObject& InJSONObject)
 {
 	TMap<FString, TSharedPtr<Ink::FObject>> dictionary;
+	dictionary.Reserve(InJSONObject.Values.Num());
 
-	const TMap<FString, TSharedPtr<FJsonValue>> jsonDict = InJSONObject.Values;
-	dictionary.Reserve(jsonDict.Num());
-
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& pair : jsonDict)
+	for (const auto& pair : InJSONObject.Values)
 	{
-		dictionary.Add(pair.Key, TSharedPtr<FObject>(JsonTokenToRuntimeObject(*pair.Value)));
+		dictionary.Add(FString(*pair.Key), TSharedPtr<FObject>(JsonTokenToRuntimeObject(*pair.Value)));
 	}
 
 	return dictionary;
@@ -123,15 +121,13 @@ TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonSerialisation::JsonObjectToDic
 TMap<FString, int32> Ink::FJsonSerialisation::JsonObjectToIntDictionary(const FJsonObject& InJSONObject)
 {
 	TMap<FString, int32> dictionary;
+	dictionary.Reserve(InJSONObject.Values.Num());
 
-	const TMap<FString, TSharedPtr<FJsonValue>> jsonDict = InJSONObject.Values;
-	dictionary.Reserve(jsonDict.Num());
-
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& pair : jsonDict)
+	for (const auto& pair : InJSONObject.Values)
 	{
 		int32 value;
 		if (pair.Value->TryGetNumber(value))
-			dictionary.Add(pair.Key, value);
+			dictionary.Add(FString(*pair.Key), value);
 		else
 			UE_LOG(InkPlusPlus, Error, TEXT("JsonSerialisation : could not convert %s to int"), *pair.Value->AsString());
 	}
@@ -187,9 +183,10 @@ TSharedPtr<Ink::FContainer> Ink::FJsonSerialisation::JsonArrayToContainer(const 
 	{
 		TMap<FString, TSharedPtr<Ink::FObject>> namedOnlyContent;
 		namedOnlyContent.Reserve(terminatingObject->Get()->Values.Num());
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& pair : terminatingObject->Get()->Values)
+		for (const auto& pair : terminatingObject->Get()->Values)
 		{
-			if (pair.Key == TEXT("#f"))
+			const FString key = FString(*pair.Key);
+			if (key == TEXT("#f"))
 			{
 				uint8 countFlags;
 				if (!pair.Value->TryGetNumber(countFlags))
@@ -200,7 +197,7 @@ TSharedPtr<Ink::FContainer> Ink::FJsonSerialisation::JsonArrayToContainer(const 
 				container->SetCountFlags(static_cast<Ink::ECountFlags>(countFlags));
 			}
 
-			else if (pair.Key == TEXT("#n"))
+			else if (key == TEXT("#n"))
 			{
 				FString name;
 				if (!pair.Value->TryGetString(name))
@@ -216,9 +213,9 @@ TSharedPtr<Ink::FContainer> Ink::FJsonSerialisation::JsonArrayToContainer(const 
 				TSharedPtr<Ink::FObject> namedContentItem(JsonTokenToRuntimeObject(*pair.Value));
 				TSharedPtr<Ink::FContainer> namedSubContainer = FObject::DynamicCastTo<Ink::FContainer>(namedContentItem);
 				if (namedSubContainer)
-					namedSubContainer->SetName(pair.Key);
+					namedSubContainer->SetName(key);
 
-				namedOnlyContent.Add(pair.Key, namedContentItem);
+				namedOnlyContent.Add(key, namedContentItem);
 			}
 		}
 		container->SetNamedOnlyContent(namedOnlyContent);
@@ -772,9 +769,10 @@ TSharedPtr<Ink::FObject> Ink::FJsonSerialisation::JsonTokenToRuntimeObject(const
 		// List Value
 		if (Ink::FJsonExtension::TryGetField(TEXT("list"), *objectValue, propertyValue))
 		{
-			TMap<FString, TSharedPtr<FJsonValue>> listContent = propertyValue->AsObject()->Values;
-			
-			Ink::FInkList rawList;			
+			// Hold the object alive: propertyValue is reused for "origins" below.
+			const TSharedPtr<FJsonObject> listContentObject = propertyValue->AsObject();
+
+			Ink::FInkList rawList;
 			if (Ink::FJsonExtension::TryGetField(TEXT("origins"), *objectValue, propertyValue))
 			{
 				const TArray<TSharedPtr<FJsonValue>> namesAsObjects = propertyValue->AsArray();
@@ -788,10 +786,10 @@ TSharedPtr<Ink::FObject> Ink::FJsonSerialisation::JsonTokenToRuntimeObject(const
 				rawList.SetInitialOriginNames(objectNames);
 			}
 
-			rawList.Reserve(listContent.Num());
-			for (const TPair<FString, TSharedPtr<FJsonValue>>& pair : listContent)
+			rawList.Reserve(listContentObject->Values.Num());
+			for (const auto& pair : listContentObject->Values)
 			{
-				Ink::FInkListItem item(pair.Key);
+				Ink::FInkListItem item(FString(*pair.Key));
 				int32 value = 0;
 				pair.Value->TryGetNumber(value);
 				rawList.Add(item, value);
@@ -827,9 +825,9 @@ TSharedPtr<Ink::FListDefinitionsOrigin> Ink::FJsonSerialisation::JsonTokenToList
 	}
 
 	TArray<TSharedPtr<Ink::FListDefinition>> allDefinitions;
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& pair : definitionsObject->Get()->Values)
+	for (const auto& pair : definitionsObject->Get()->Values)
 	{
-		const FString name = pair.Key;
+		const FString name = FString(*pair.Key);
 		const TSharedPtr<FJsonObject>* listDefinitionJson;
 		if (!pair.Value->TryGetObject(listDefinitionJson))
 		{
@@ -840,7 +838,7 @@ TSharedPtr<Ink::FListDefinitionsOrigin> Ink::FJsonSerialisation::JsonTokenToList
 		// Cast (string, value) to (string, int) for items
 		TMap<FString, int32> items;
 		items.Reserve(listDefinitionJson->Get()->Values.Num());
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& definitionsPair : listDefinitionJson->Get()->Values)
+		for (const auto& definitionsPair : listDefinitionJson->Get()->Values)
 		{
 			int32 value;
 			if (!definitionsPair.Value->TryGetNumber(value))
@@ -848,7 +846,7 @@ TSharedPtr<Ink::FListDefinitionsOrigin> Ink::FJsonSerialisation::JsonTokenToList
 				UE_LOG(InkPlusPlus, Error, TEXT("JsonSerialisation : failed to get int value out of definition pair"));
 				continue;
 			}
-			items.Add(definitionsPair.Key, value);
+			items.Add(FString(*definitionsPair.Key), value);
 		}
 
 		TSharedPtr<Ink::FListDefinition> listDefinition = MakeShared<Ink::FListDefinition>(name, items);

--- a/Source/InkPlusPlus/Private/Ink/StoryState.cpp
+++ b/Source/InkPlusPlus/Private/Ink/StoryState.cpp
@@ -86,7 +86,7 @@ void Ink::FStoryState::LoadJSONObj(const FJsonObject& InJSONObj)
 	const TSharedPtr<FJsonObject>* flowsObject = nullptr;
 	if (InJSONObj.TryGetObjectField(TEXT("flows"), flowsObject))
 	{
-		TMap<FString, TSharedPtr<FJsonValue>> flowsObjectMap = flowsObject->Get()->Values;
+		const auto& flowsObjectMap = flowsObject->Get()->Values;
 
 		if (flowsObjectMap.Num() == 1) // Single default flow
 		{
@@ -102,9 +102,9 @@ void Ink::FStoryState::LoadJSONObj(const FJsonObject& InJSONObj)
 		}
 
 		// Load up each flow (there may only be one)
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& flowPair : flowsObjectMap)
+		for (const auto& flowPair : flowsObjectMap)
 		{
-			FString name = flowPair.Key;
+			FString name = FString(*flowPair.Key);
 			const TSharedPtr<FJsonObject> flowObject = flowPair.Value->AsObject();
 
 			// Load up this flow using JSON data
@@ -149,8 +149,7 @@ void Ink::FStoryState::LoadJSONObj(const FJsonObject& InJSONObj)
 	const TSharedPtr<FJsonObject>* variableStateObjectField = nullptr;
 	if (InJSONObj.TryGetObjectField(TEXT("variablesState"), variableStateObjectField))
 	{
-		const TMap<FString, TSharedPtr<FJsonValue>> variableStateObjectMap = variableStateObjectField->Get()->Values;
-		VariableState->SetJsonToken(variableStateObjectMap);
+		VariableState->SetJsonToken(*variableStateObjectField->Get());
 		VariableState->SetCallStack(CurrentFlow->GetCallStack());
 	}
 
@@ -166,11 +165,9 @@ void Ink::FStoryState::LoadJSONObj(const FJsonObject& InJSONObj)
 		DivertedPointer = Story->PointerAtPath(divertPath);
 	}
 
-	TMap<FString, TSharedPtr<FJsonValue>> visitCountsDictionary = InJSONObj.GetObjectField(TEXT("visitCounts")).Get()->Values;
-	VisitCounts = Ink::FJsonExtension::JSONObjectToIntDictionary(visitCountsDictionary);
+	VisitCounts = Ink::FJsonExtension::JSONObjectToIntDictionary(*InJSONObj.GetObjectField(TEXT("visitCounts")).Get());
 
-	TMap<FString, TSharedPtr<FJsonValue>> turnIndicesDictionary = InJSONObj.GetObjectField(TEXT("turnIndices")).Get()->Values;
-	TurnIndices = Ink::FJsonExtension::JSONObjectToIntDictionary(turnIndicesDictionary);
+	TurnIndices = Ink::FJsonExtension::JSONObjectToIntDictionary(*InJSONObj.GetObjectField(TEXT("turnIndices")).Get());
 
 	CurrentTurnIndex = InJSONObj.GetIntegerField(TEXT("turnIdx"));
 	StorySeed = InJSONObj.GetIntegerField(TEXT("storySeed"));

--- a/Source/InkPlusPlus/Private/Ink/VariableState.cpp
+++ b/Source/InkPlusPlus/Private/Ink/VariableState.cpp
@@ -127,7 +127,7 @@ void Ink::FVariableState::ApplyPatch()
 }
 
 
-void Ink::FVariableState::SetJsonToken(const TMap<FString, TSharedPtr<FJsonValue>>& JsonToken)
+void Ink::FVariableState::SetJsonToken(const FJsonObject& InJSONToken)
 {
 	_globalVariables.Reset();
 
@@ -135,10 +135,10 @@ void Ink::FVariableState::SetJsonToken(const TMap<FString, TSharedPtr<FJsonValue
 	{
 		const FString variableName = variablePair.Key;
 
-		const TSharedPtr<FJsonValue>* loadedTokenPtrPtr = JsonToken.Find(variableName);
-		if (loadedTokenPtrPtr != nullptr && (*loadedTokenPtrPtr).IsValid())
+		const TSharedPtr<FJsonValue> loadedToken = InJSONToken.TryGetField(variableName);
+		if (loadedToken.IsValid())
 		{
-			_globalVariables.Emplace( variableName, Ink::FJsonSerialisation::JsonTokenToRuntimeObject(**loadedTokenPtrPtr) );
+			_globalVariables.Emplace( variableName, Ink::FJsonSerialisation::JsonTokenToRuntimeObject(*loadedToken) );
 		}
 		else
 		{

--- a/Source/InkPlusPlus/Public/Ink/Flow.h
+++ b/Source/InkPlusPlus/Public/Ink/Flow.h
@@ -20,7 +20,7 @@ namespace Ink
 		void WriteJSON(TJsonWriter<>* InJSONWriter);
 
 		// Used both to load old format and current
-		void LoadFlowChoiceThreads(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONChoiceThreads,  const Ink::FStory& InStory);
+		void LoadFlowChoiceThreads(const FJsonObject& InJSONChoiceThreads,  const Ink::FStory& InStory);
 
 		TSharedPtr<Ink::FCallStack> GetCallStack() const;
 		void SetCallStack(const Ink::FCallStack& InCallStack);

--- a/Source/InkPlusPlus/Public/Ink/JsonExtension.h
+++ b/Source/InkPlusPlus/Public/Ink/JsonExtension.h
@@ -8,7 +8,7 @@ namespace Ink
 	struct FJsonExtension
 	{
 		static TMap<FString, TSharedPtr<Ink::FObject>> JSONObjectToInkObject(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONObject);
-		static TMap<FString, int32> JSONObjectToIntDictionary(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONObject);
+		static TMap<FString, int32> JSONObjectToIntDictionary(const FJsonObject& InJSONObject);
 		static TArray<TSharedPtr<Ink::FObject>> JSONValueToInkObject(const TArray<TSharedPtr<FJsonValue>>& InJSONArray);
 		static TSharedPtr<Ink::FObject> JSONTokenToInkObject(const TSharedPtr<FJsonValue> InJSONToken);
 

--- a/Source/InkPlusPlus/Public/Ink/VariableState.h
+++ b/Source/InkPlusPlus/Public/Ink/VariableState.h
@@ -39,7 +39,7 @@ namespace Ink
 		bool SetVariable(const FString& VariableName, const TSharedPtr<Ink::FObject>& Value);
 
 		void ApplyPatch();
-		void SetJsonToken(const TMap<FString, TSharedPtr<FJsonValue>>& JsonToken);
+		void SetJsonToken(const FJsonObject& InJSONToken);
 		void WriteJson(TJsonWriter<>* Writer);
 		bool RuntimeObjectsEqual(TSharedPtr<Ink::FObject> Object1, TSharedPtr<Ink::FObject> Object2) const;
 

--- a/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
+++ b/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
@@ -289,10 +289,13 @@ bool FInkTests::RunTest(const FString& InkTestName)
 			for (TSharedPtr<FJsonValue> element : Array)
 			{
 				const TSharedPtr<FJsonObject>& testInstruction = element->AsObject();
-
-
+				
 				TArray<FString> keys;
-				testInstruction->Values.GetKeys(keys);
+				keys.Reserve(testInstruction->Values.Num());
+				for (const auto& valuePair : testInstruction->Values)
+				{
+					keys.Add(FString(*valuePair.Key));
+				}
 				if (keys.Num() != 1)
 				{
 					INKPOT_ERROR("Invalid test script, expected only one field per instruction: %s\n", *InkTestName);
@@ -701,7 +704,7 @@ bool FInkTests::RunTest(const FString& InkTestName)
 									TSharedPtr<FJsonValue> value = (*expectedTags)[i];
 									if (value->Type != EJson::String)
 									{
-										INKPOT_ERROR("%s : TEST_CURRENT_TAGS Tag is not a string, check test script JSON\n", *InkTestName, expectedTags->Num(), actualTags.Num());
+										INKPOT_ERROR("%s : TEST_CURRENT_TAGS Tag is not a string, check test script JSON\n", *InkTestName);
 										return false;
 									}
 
@@ -749,7 +752,7 @@ bool FInkTests::RunTest(const FString& InkTestName)
 									TSharedPtr<FJsonValue> value = (*expectedTags)[i];
 									if (value->Type != EJson::String)
 									{
-										INKPOT_ERROR("%s : TEST_STORY_GLOBAL_TAGS Tag is not a string, check test script JSON\n", *InkTestName, expectedTags->Num(), actualTags.Num());
+										INKPOT_ERROR("%s : TEST_STORY_GLOBAL_TAGS Tag is not a string, check test script JSON\n", *InkTestName);
 										return false;
 									}
 


### PR DESCRIPTION
UE 5.8 changed FJsonObject::Values keys from FString to UE::FSharedString (FJsonObject::FStringType), gated by the engine-baked UE_JSONOBJECT_LEGACY_STRING_KEYS macro. Direct TMap<FString,...> access and FString-keyed iteration no longer compile.

- Iterate Values directly and convert keys via FString(*Pair.Key), which works on both FString and FSharedString (both expose operator* -> const TCHAR*), so this also builds on 5.6/5.7.

- Retype the choiceThreads / variableState / visit-count helpers to take const FJsonObject& and use FStringView accessors (TryGetObjectField / TryGetField), avoiding key-type leakage and the old map[] lookups (also null-safe on missing keys).

- Fix two format-string arg-count mismatches now caught at compile time by 5.8's FormatStringSan static_assert.

Compiled with UE 5.7 and UE 5.8
Full test suite passed for both