### PR TITLE
Update Inkpot for Unreal Engine 5.8, fix broken tests, and fix capitalization on includes.

### DIFF
--- a/Source/InkPlusPlus/Private/Ink/CallStack.cpp
+++ b/Source/InkPlusPlus/Private/Ink/CallStack.cpp
@@ -457,7 +457,7 @@ TSharedPtr<Ink::FObject> Ink::FCallStack::GetTemporaryVariableWithName(const FSt
 
 
 	const TSharedPtr<Ink::FElement> contextElement = callStack[InContextIndex - 1];
-	const TSharedPtr<Ink::FObject>* object = contextElement->TemporaryVariables.Find(InName);
+	const TSharedPtr<Ink::FObject>* object = contextElement->TemporaryVariables.Find(*InName);
 	if (object != nullptr && object->IsValid())
 		return *object;
 
@@ -477,24 +477,24 @@ void Ink::FCallStack::SetTemporaryVariable(const FString& InName, TSharedPtr<Ink
 	}
 
 	const TSharedPtr<Ink::FElement> contextElement = callStack[InContextIndex - 1];
-	if(!InDeclareNew && !contextElement->TemporaryVariables.Contains(InName))
+	if(!InDeclareNew && !contextElement->TemporaryVariables.Contains(*InName))
 	{
 		UE_LOG(InkPlusPlus, Error, TEXT("CallStack : could not find temporary variable to set: %s"), *InName);
 		return;;
 	}
 
-	TSharedPtr<Ink::FObject>* oldValue = contextElement->TemporaryVariables.Find(InName);
+	TSharedPtr<Ink::FObject>* oldValue = contextElement->TemporaryVariables.Find(*InName);
 	if (oldValue != nullptr && oldValue->IsValid())
 		Ink::FValueList::RetainListOriginsForAssignment(*oldValue, InValue);
 
-	contextElement->TemporaryVariables.Add(InName, InValue);
+	contextElement->TemporaryVariables.Add(*InName, InValue);
 }
 
 int32 Ink::FCallStack::ContextForVariableNamed(const FString& InName)
 {
 	// Current temporary context?
 	// (Shouldn't attempt to access contexts higher in the callstack.)
-	if (CurrentElement()->TemporaryVariables.Contains(InName))
+	if (CurrentElement()->TemporaryVariables.Contains(*InName))
 		return GetCurrentElementIndex() + 1;
 
 	// Global

--- a/Source/InkPlusPlus/Private/Ink/Flow.cpp
+++ b/Source/InkPlusPlus/Private/Ink/Flow.cpp
@@ -1,4 +1,4 @@
-﻿#include "Ink/Flow.h"
+#include "Ink/Flow.h"
 
 #include "Utility/InkPlusPlusLog.h"
 #include "Ink/Story.h"
@@ -91,7 +91,7 @@ void Ink::FFlow::WriteJSON(TJsonWriter<>* InJSONWriter)
 	InJSONWriter->WriteObjectEnd();
 }
 
-void Ink::FFlow::LoadFlowChoiceThreads(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONChoiceThreads, const Ink::FStory& InStory)
+void Ink::FFlow::LoadFlowChoiceThreads(const TMap<FStringType, TSharedPtr<FJsonValue>>& InJSONChoiceThreads, const Ink::FStory& InStory)
 {
 	for (const TSharedPtr<Ink::FChoice>& choice : *CurrentChoices)
 	{
@@ -102,7 +102,7 @@ void Ink::FFlow::LoadFlowChoiceThreads(const TMap<FString, TSharedPtr<FJsonValue
 		}
 		else
 		{
-			const TSharedPtr<FJsonValue> jsonSavedChoiceThread = InJSONChoiceThreads[FString::FromInt(choice->GetOriginalThreadIndex())];
+			const TSharedPtr<FJsonValue> jsonSavedChoiceThread = InJSONChoiceThreads[*FString::FromInt(choice->GetOriginalThreadIndex())];
 			const TSharedPtr<FJsonObject>* jsonSavedChoiceThreadObject;
 			if (!jsonSavedChoiceThread->TryGetObject(jsonSavedChoiceThreadObject))
 			{

--- a/Source/InkPlusPlus/Private/Ink/JsonExtension.cpp
+++ b/Source/InkPlusPlus/Private/Ink/JsonExtension.cpp
@@ -1,16 +1,16 @@
-﻿#include "Ink/JsonExtension.h"
+#include "Ink/JsonExtension.h"
 #include "Ink/Object.h"
 #include "Ink/JsonSerialisation.h"
 
 
-TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonExtension::JSONObjectToInkObject(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONObject)
+TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonExtension::JSONObjectToInkObject(const TMap<FStringType, TSharedPtr<FJsonValue>>& InJSONObject)
 {
 	TMap<FString, TSharedPtr<Ink::FObject>> convertedMap;
 	convertedMap.Reserve(InJSONObject.Num());
 
 	for (const TPair<FString, TSharedPtr<FJsonValue>>& jsonPair : InJSONObject)
 	{
-		const FString& key = jsonPair.Key;
+		const FString& key = *jsonPair.Key;
 		TSharedPtr<Ink::FObject> value(Ink::FJsonSerialisation::JsonTokenToRuntimeObject(*jsonPair.Value));
 		convertedMap.Add(jsonPair.Key, value);
 	}
@@ -18,14 +18,14 @@ TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonExtension::JSONObjectToInkObje
 	return convertedMap;
 }
 
-TMap<FString, int32> Ink::FJsonExtension::JSONObjectToIntDictionary(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONObject)
+TMap<FString, int32> Ink::FJsonExtension::JSONObjectToIntDictionary(const TMap<FStringType, TSharedPtr<FJsonValue>>& InJSONObject)
 {
 	TMap<FString, int32> convertedMap;
 	convertedMap.Reserve(InJSONObject.Num());
 
 	for (const TPair<FString, TSharedPtr<FJsonValue>>& jsonPair : InJSONObject)
 	{
-		const FString& key = jsonPair.Key;
+		const FString& key = *jsonPair.Key;
 		int32 value = static_cast<int32>(jsonPair.Value->AsNumber());
 		convertedMap.Add(jsonPair.Key, value);
 	}

--- a/Source/InkPlusPlus/Private/Ink/JsonSerialisation.cpp
+++ b/Source/InkPlusPlus/Private/Ink/JsonSerialisation.cpp
@@ -1,4 +1,4 @@
-﻿#include "Ink/JsonSerialisation.h"
+#include "Ink/JsonSerialisation.h"
 
 #include "Ink/Object.h"
 #include "Ink/Container.h"
@@ -105,14 +105,14 @@ TSharedPtr<TArray<TSharedPtr<Ink::FChoice>>> Ink::FJsonSerialisation::JsonArrayT
 	return list;
 }
 
-TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonSerialisation::JsonObjectToDictionaryRuntimeObjects(const FJsonObject& InJSONObject)
+TMap<Ink::FStringType, TSharedPtr<Ink::FObject>> Ink::FJsonSerialisation::JsonObjectToDictionaryRuntimeObjects(const FJsonObject& InJSONObject)
 {
-	TMap<FString, TSharedPtr<Ink::FObject>> dictionary;
+	TMap<FStringType, TSharedPtr<Ink::FObject>> dictionary;
 
-	const TMap<FString, TSharedPtr<FJsonValue>> jsonDict = InJSONObject.Values;
+	const TMap<FStringType, TSharedPtr<FJsonValue>>& jsonDict = InJSONObject.Values;
 	dictionary.Reserve(jsonDict.Num());
 
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& pair : jsonDict)
+	for (const TPair<FStringType, TSharedPtr<FJsonValue>>& pair : jsonDict)
 	{
 		dictionary.Add(pair.Key, TSharedPtr<FObject>(JsonTokenToRuntimeObject(*pair.Value)));
 	}
@@ -120,14 +120,14 @@ TMap<FString, TSharedPtr<Ink::FObject>> Ink::FJsonSerialisation::JsonObjectToDic
 	return dictionary;
 }
 
-TMap<FString, int32> Ink::FJsonSerialisation::JsonObjectToIntDictionary(const FJsonObject& InJSONObject)
+TMap<Ink::FStringType, int32> Ink::FJsonSerialisation::JsonObjectToIntDictionary(const FJsonObject& InJSONObject)
 {
-	TMap<FString, int32> dictionary;
+	TMap<FStringType, int32> dictionary;
 
-	const TMap<FString, TSharedPtr<FJsonValue>> jsonDict = InJSONObject.Values;
+	const TMap<FStringType, TSharedPtr<FJsonValue>>& jsonDict = InJSONObject.Values;
 	dictionary.Reserve(jsonDict.Num());
 
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& pair : jsonDict)
+	for (const TPair<FStringType, TSharedPtr<FJsonValue>>& pair : jsonDict)
 	{
 		int32 value;
 		if (pair.Value->TryGetNumber(value))
@@ -227,7 +227,7 @@ TSharedPtr<Ink::FContainer> Ink::FJsonSerialisation::JsonArrayToContainer(const 
 	return container;
 }
 
-void Ink::FJsonSerialisation::WriteDictionaryRuntimeObjects(TJsonWriter<>* InJSONWriter, const TMap<FString, TSharedPtr<Ink::FObject>>& InDictionary)
+void Ink::FJsonSerialisation::WriteDictionaryRuntimeObjects(TJsonWriter<>* InJSONWriter, const TMap<FStringType, TSharedPtr<Ink::FObject>>& InDictionary)
 {
 	InJSONWriter->WriteObjectStart();
 	for (const TPair<FString, TSharedPtr<Ink::FObject>>& pair : InDictionary)
@@ -248,7 +248,7 @@ void Ink::FJsonSerialisation::WriteListRuntimeObjects(TJsonWriter<>* InJSONWrite
 	InJSONWriter->WriteArrayEnd();
 }
 
-void Ink::FJsonSerialisation::WriteIntDictionary(TJsonWriter<>* InJSONWriter,const TMap<FString, int32>& InDictionary)
+void Ink::FJsonSerialisation::WriteIntDictionary(TJsonWriter<>* InJSONWriter,const TMap<FStringType, int32>& InDictionary)
 {
 	InJSONWriter->WriteObjectStart();
 	for (const TPair<FString, int32>& pair : InDictionary)
@@ -772,7 +772,7 @@ TSharedPtr<Ink::FObject> Ink::FJsonSerialisation::JsonTokenToRuntimeObject(const
 		// List Value
 		if (Ink::FJsonExtension::TryGetField(TEXT("list"), *objectValue, propertyValue))
 		{
-			TMap<FString, TSharedPtr<FJsonValue>> listContent = propertyValue->AsObject()->Values;
+			TMap<FStringType, TSharedPtr<FJsonValue>> listContent = propertyValue->AsObject()->Values;
 			
 			Ink::FInkList rawList;			
 			if (Ink::FJsonExtension::TryGetField(TEXT("origins"), *objectValue, propertyValue))

--- a/Source/InkPlusPlus/Private/Ink/StoryState.cpp
+++ b/Source/InkPlusPlus/Private/Ink/StoryState.cpp
@@ -86,7 +86,7 @@ void Ink::FStoryState::LoadJSONObj(const FJsonObject& InJSONObj)
 	const TSharedPtr<FJsonObject>* flowsObject = nullptr;
 	if (InJSONObj.TryGetObjectField(TEXT("flows"), flowsObject))
 	{
-		TMap<FString, TSharedPtr<FJsonValue>> flowsObjectMap = flowsObject->Get()->Values;
+		TMap<Ink::FStringType, TSharedPtr<FJsonValue>> flowsObjectMap = flowsObject->Get()->Values;
 
 		if (flowsObjectMap.Num() == 1) // Single default flow
 		{
@@ -149,7 +149,7 @@ void Ink::FStoryState::LoadJSONObj(const FJsonObject& InJSONObj)
 	const TSharedPtr<FJsonObject>* variableStateObjectField = nullptr;
 	if (InJSONObj.TryGetObjectField(TEXT("variablesState"), variableStateObjectField))
 	{
-		const TMap<FString, TSharedPtr<FJsonValue>> variableStateObjectMap = variableStateObjectField->Get()->Values;
+		const TMap<Ink::FStringType, TSharedPtr<FJsonValue>> variableStateObjectMap = variableStateObjectField->Get()->Values;
 		VariableState->SetJsonToken(variableStateObjectMap);
 		VariableState->SetCallStack(CurrentFlow->GetCallStack());
 	}
@@ -166,10 +166,10 @@ void Ink::FStoryState::LoadJSONObj(const FJsonObject& InJSONObj)
 		DivertedPointer = Story->PointerAtPath(divertPath);
 	}
 
-	TMap<FString, TSharedPtr<FJsonValue>> visitCountsDictionary = InJSONObj.GetObjectField(TEXT("visitCounts")).Get()->Values;
+	TMap<Ink::FStringType, TSharedPtr<FJsonValue>> visitCountsDictionary = InJSONObj.GetObjectField(TEXT("visitCounts")).Get()->Values;
 	VisitCounts = Ink::FJsonExtension::JSONObjectToIntDictionary(visitCountsDictionary);
 
-	TMap<FString, TSharedPtr<FJsonValue>> turnIndicesDictionary = InJSONObj.GetObjectField(TEXT("turnIndices")).Get()->Values;
+	TMap<Ink::FStringType, TSharedPtr<FJsonValue>> turnIndicesDictionary = InJSONObj.GetObjectField(TEXT("turnIndices")).Get()->Values;
 	TurnIndices = Ink::FJsonExtension::JSONObjectToIntDictionary(turnIndicesDictionary);
 
 	CurrentTurnIndex = InJSONObj.GetIntegerField(TEXT("turnIdx"));

--- a/Source/InkPlusPlus/Private/Ink/VariableState.cpp
+++ b/Source/InkPlusPlus/Private/Ink/VariableState.cpp
@@ -1,4 +1,4 @@
-﻿#include "Ink/VariableState.h"
+#include "Ink/VariableState.h"
 #include "Ink/Value.h"
 #include "Ink/Object.h"
 #include "Ink/JsonSerialisation.h"
@@ -127,7 +127,7 @@ void Ink::FVariableState::ApplyPatch()
 }
 
 
-void Ink::FVariableState::SetJsonToken(const TMap<FString, TSharedPtr<FJsonValue>>& JsonToken)
+void Ink::FVariableState::SetJsonToken(const TMap<FStringType, TSharedPtr<FJsonValue>>& JsonToken)
 {
 	_globalVariables.Reset();
 
@@ -135,7 +135,7 @@ void Ink::FVariableState::SetJsonToken(const TMap<FString, TSharedPtr<FJsonValue
 	{
 		const FString variableName = variablePair.Key;
 
-		const TSharedPtr<FJsonValue>* loadedTokenPtrPtr = JsonToken.Find(variableName);
+		const TSharedPtr<FJsonValue>* loadedTokenPtrPtr = JsonToken.Find(*variableName);
 		if (loadedTokenPtrPtr != nullptr && (*loadedTokenPtrPtr).IsValid())
 		{
 			_globalVariables.Emplace( variableName, Ink::FJsonSerialisation::JsonTokenToRuntimeObject(**loadedTokenPtrPtr) );

--- a/Source/InkPlusPlus/Public/Ink/CallStack.h
+++ b/Source/InkPlusPlus/Public/Ink/CallStack.h
@@ -1,15 +1,18 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "PushPop.h"
 #include "Json.h"
 #include "Pointer.h"
+#include "Containers/StringFwd.h"
 
 namespace Ink
 {
 	class FObject;
 	class FStory;
 	class FThread;
+
+	using FStringType = UE::FSharedString;
 
 
 #pragma region Element
@@ -43,7 +46,7 @@ namespace Ink
 		they generate, so we make sure know where the function's start and end are.	*/
 		int32 FunctionStartInOutputStream;
 
-		TMap<FString, TSharedPtr<Ink::FObject>> TemporaryVariables;
+		TMap<FStringType, TSharedPtr<Ink::FObject>> TemporaryVariables;
 	
 	private:
 		bool bInExpressionEvaluation;

--- a/Source/InkPlusPlus/Public/Ink/Flow.h
+++ b/Source/InkPlusPlus/Public/Ink/Flow.h
@@ -1,6 +1,7 @@
-﻿#pragma once
+#pragma once
 #include "CoreMinimal.h"
 #include "Json.h"
+#include "Containers/StringFwd.h"
 
 
 namespace Ink
@@ -9,7 +10,9 @@ namespace Ink
 	class FObject;
 	class FChoice;
 	class FCallStack;
-	
+
+	using FStringType = UE::FSharedString;
+
 	class FFlow
 	{
 	public:
@@ -20,7 +23,7 @@ namespace Ink
 		void WriteJSON(TJsonWriter<>* InJSONWriter);
 
 		// Used both to load old format and current
-		void LoadFlowChoiceThreads(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONChoiceThreads,  const Ink::FStory& InStory);
+		void LoadFlowChoiceThreads(const TMap<FStringType, TSharedPtr<FJsonValue>>& InJSONChoiceThreads,  const Ink::FStory& InStory);
 
 		TSharedPtr<Ink::FCallStack> GetCallStack() const;
 		void SetCallStack(const Ink::FCallStack& InCallStack);

--- a/Source/InkPlusPlus/Public/Ink/JsonExtension.h
+++ b/Source/InkPlusPlus/Public/Ink/JsonExtension.h
@@ -1,14 +1,18 @@
-﻿#pragma once
+#pragma once
 #include "Json.h"
+#include "Containers/StringFwd.h"
+
 
 namespace Ink
 {
 	class FObject;
-	
+
+	using FStringType = UE::FSharedString;
+
 	struct FJsonExtension
 	{
-		static TMap<FString, TSharedPtr<Ink::FObject>> JSONObjectToInkObject(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONObject);
-		static TMap<FString, int32> JSONObjectToIntDictionary(const TMap<FString, TSharedPtr<FJsonValue>>& InJSONObject);
+		static TMap<FString, TSharedPtr<Ink::FObject>> JSONObjectToInkObject(const TMap<FStringType, TSharedPtr<FJsonValue>>& InJSONObject);
+		static TMap<FString, int32> JSONObjectToIntDictionary(const TMap<FStringType, TSharedPtr<FJsonValue>>& InJSONObject);
 		static TArray<TSharedPtr<Ink::FObject>> JSONValueToInkObject(const TArray<TSharedPtr<FJsonValue>>& InJSONArray);
 		static TSharedPtr<Ink::FObject> JSONTokenToInkObject(const TSharedPtr<FJsonValue> InJSONToken);
 

--- a/Source/InkPlusPlus/Public/Ink/JsonSerialisation.h
+++ b/Source/InkPlusPlus/Public/Ink/JsonSerialisation.h
@@ -1,7 +1,8 @@
-﻿#pragma once
+#pragma once
 #include "CoreMinimal.h"
 #include "Json.h"
 #include "Utility/InkPlusPlusLog.h"
+#include "Containers/StringFwd.h"
 
 namespace Ink
 {
@@ -11,6 +12,8 @@ namespace Ink
 	class FValueList;
 	class FListDefinitionsOrigin;
 
+	using FStringType = UE::FSharedString;
+
 	// May need wrappers for "WritePropertyStart / WritePropertyEnd" that are in source parser (SimpleJson), currently just using Unreal's Write Value and hope to be sufficient
 	class INKPLUSPLUS_API FJsonSerialisation
 	{
@@ -19,15 +22,15 @@ namespace Ink
 		
 		static TArray<TSharedPtr<Ink::FObject>> JsonArrayToRuntimeObjectList(const TArray<TSharedPtr<FJsonValue>>& InJSONArray, bool InSkipLast = false);
 		static TSharedPtr<TArray<TSharedPtr<Ink::FChoice>>> JsonArrayToChoiceList(const TArray<TSharedPtr<FJsonValue>>& InJSONArray, bool InSkipLast = false);
-		static TMap<FString, TSharedPtr<Ink::FObject>> JsonObjectToDictionaryRuntimeObjects(const FJsonObject& InJSONObject);
-		static TMap<FString, int32> JsonObjectToIntDictionary(const FJsonObject& InJSONObject);
+		static TMap<FStringType, TSharedPtr<Ink::FObject>> JsonObjectToDictionaryRuntimeObjects(const FJsonObject& InJSONObject);
+		static TMap<FStringType, int32> JsonObjectToIntDictionary(const FJsonObject& InJSONObject);
 		static TSharedPtr<Ink::FChoice> JsonObjectToChoice(const FJsonObject& InJSONObject);
 
 		static TSharedPtr<Ink::FContainer> JsonArrayToContainer(const TArray<TSharedPtr<FJsonValue>>& InJSONArray);
 		
-		static void WriteDictionaryRuntimeObjects(TJsonWriter<>* InJSONWriter, const TMap<FString, TSharedPtr<Ink::FObject>>& InDictionary);
+		static void WriteDictionaryRuntimeObjects(TJsonWriter<>* InJSONWriter, const TMap<FStringType, TSharedPtr<Ink::FObject>>& InDictionary);
 		static void WriteListRuntimeObjects(TJsonWriter<>* InJSONWriter, const TArray<TSharedPtr<Ink::FObject>>& InList);
-		static void WriteIntDictionary(TJsonWriter<>* InJSONWriter, const TMap<FString, int32>& InDictionary);
+		static void WriteIntDictionary(TJsonWriter<>* InJSONWriter, const TMap<FStringType, int32>& InDictionary);
 		static void WriteRuntimeObject(TJsonWriter<>* InJSONWriter, TSharedPtr<Ink::FObject> InObject);
 		static void WriteRuntimeContainer(TJsonWriter<>* InJSONWriter, const Ink::FContainer& InContainer, bool InWithoutName = false);
 

--- a/Source/InkPlusPlus/Public/Ink/VariableState.h
+++ b/Source/InkPlusPlus/Public/Ink/VariableState.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "CoreMinimal.h"
 #include "Object.h"
 #include "CallStack.h"
@@ -6,6 +6,7 @@
 #include "VariableAssignment.h"
 #include "Dom/JsonValue.h"
 #include "ListDefinitionsOrigin.h"
+#include "Containers/StringFwd.h"
 
 DECLARE_MULTICAST_DELEGATE_TwoParams(FInkVariableObserver, const FString&, TSharedPtr<Ink::FObject>);
 
@@ -15,6 +16,8 @@ class JsonObject;
 namespace Ink
 {
 	class FValueVariablePointer;
+
+	using FStringType = UE::FSharedString;
 
 
 	class INKPLUSPLUS_API FVariableState
@@ -39,7 +42,7 @@ namespace Ink
 		bool SetVariable(const FString& VariableName, const TSharedPtr<Ink::FObject>& Value);
 
 		void ApplyPatch();
-		void SetJsonToken(const TMap<FString, TSharedPtr<FJsonValue>>& JsonToken);
+		void SetJsonToken(const TMap<FStringType, TSharedPtr<FJsonValue>>& JsonToken);
 		void WriteJson(TJsonWriter<>* Writer);
 		bool RuntimeObjectsEqual(TSharedPtr<Ink::FObject> Object1, TSharedPtr<Ink::FObject> Object2) const;
 

--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -7,7 +7,7 @@
 #include "Ink/StoryState.h"
 #include "Ink/SearchResult.h"
 #include "Ink/Path.h"
-#include "Ink/Inklist.h"
+#include "Ink/InkList.h"
 #include "Utility/InkpotLog.h"
 #include "Inkpot/InkpotGameplayTagLibrary.h"
 

--- a/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
+++ b/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
@@ -701,7 +701,7 @@ bool FInkTests::RunTest(const FString& InkTestName)
 									TSharedPtr<FJsonValue> value = (*expectedTags)[i];
 									if (value->Type != EJson::String)
 									{
-										INKPOT_ERROR("%s : TEST_CURRENT_TAGS Tag is not a string, check test script JSON\n", *InkTestName, expectedTags->Num(), actualTags.Num());
+										INKPOT_ERROR("%s : TEST_CURRENT_TAGS Tag is not a string, check test script JSON\n", *InkTestName);
 										return false;
 									}
 
@@ -749,7 +749,7 @@ bool FInkTests::RunTest(const FString& InkTestName)
 									TSharedPtr<FJsonValue> value = (*expectedTags)[i];
 									if (value->Type != EJson::String)
 									{
-										INKPOT_ERROR("%s : TEST_STORY_GLOBAL_TAGS Tag is not a string, check test script JSON\n", *InkTestName, expectedTags->Num(), actualTags.Num());
+										INKPOT_ERROR("%s : TEST_STORY_GLOBAL_TAGS Tag is not a string, check test script JSON\n", *InkTestName);
 										return false;
 									}
 

--- a/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
+++ b/Source/InkpotEditor/Private/Test/InkPlusPlusTest.cpp
@@ -18,6 +18,7 @@
 #include <Serialization/JsonTypes.h>
 #include <Ink/VariableState.h>
 #include "Test/InkFunctionTests.h"
+#include "Containers/StringFwd.h"
 
 
 #define TEST_ERROR_EQUAL                         TEXT("TEST_ERROR_EQUAL")
@@ -291,7 +292,7 @@ bool FInkTests::RunTest(const FString& InkTestName)
 				const TSharedPtr<FJsonObject>& testInstruction = element->AsObject();
 
 
-				TArray<FString> keys;
+				TArray<UE::FSharedString> keys;
 				testInstruction->Values.GetKeys(keys);
 				if (keys.Num() != 1)
 				{
@@ -299,7 +300,7 @@ bool FInkTests::RunTest(const FString& InkTestName)
 					return false;
 				}
 
-				const FString& instruction = keys[0];
+				const FString& instruction = *keys[0];
 				if (!IsStoryInstruction(instruction))
 				{
 					if (testInstruction->HasField(TEST_ERROR_EQUAL))

--- a/Source/InkpotEditor/Public/Blotter/BlotterVariable.h
+++ b/Source/InkpotEditor/Public/Blotter/BlotterVariable.h
@@ -2,7 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "EditorUtilityWidget.h"
-#include "ink/Object.h"
+#include "Ink/Object.h"
 #include "Blotter/BlotterOption.h"
 #include "BlotterVariable.generated.h"
 

--- a/Source/InkpotEditor/Public/GameplayTags/InkpotTagMenu.h
+++ b/Source/InkpotEditor/Public/GameplayTags/InkpotTagMenu.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Coreminimal.h"
+#include "CoreMinimal.h"
 #include "InkpotTagMenu.generated.h"
 
 UCLASS()

--- a/Source/InkpotEditor/Public/GameplayTags/InkpotTagUtility.h
+++ b/Source/InkpotEditor/Public/GameplayTags/InkpotTagUtility.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Coreminimal.h"
+#include "CoreMinimal.h"
 #include "Inkpot/InkpotStory.h"
 #include "InkpotTagUtility.generated.h"
 

--- a/Source/InkpotEditor/Public/ImportPipeline/InkpotImportPipeline.h
+++ b/Source/InkpotEditor/Public/ImportPipeline/InkpotImportPipeline.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Coreminimal.h"
+#include "CoreMinimal.h"
 #include "EditorUtilityObject.h"
 #include "IEditorUtilityExtension.h"
 #include "Logging/MessageLog.h"


### PR DESCRIPTION
I didn't see the existing pull request for fixing 5.8 build issues when I started this (pull request #138), and I approached the problem differently, so after my changes I suspect it will only build for 5.8 and later, so feel free to choose that PR over this one if that's an issue.

However, in addition to changing internals to use FStringType for JSON keys, I also corrected some other minor build errors I discovered while attempting to get InkPot to work with 5.8:

Two tests in the test suite include more parameters than the interpolated string can support. In both cases, these parameters do not make sense to include and appear to have been erroneously included from other tests.

Additionally, numerous include statements used incorrect capitalization, which causes build issues on case-insensitive systems.

All tests pass after making these changes and this plugin builds successfully both on Mac and using Unreal Engine 5.8.