### PR TITLE
Fix: SwitchFlowToPath swallows the first few lines of content

### DIFF
--- a/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
+++ b/Source/Inkpot/Private/Inkpot/InkpotStory.cpp
@@ -297,8 +297,6 @@ bool UInkpotStory::SwitchFlowToPath(const FString& InFlowName, const FString& In
 	if (bIsNewFlow || bInRestart)
 	{
 		ChoosePath(InPath);
-		if (CanContinueInternal())
-			ContinueInternal();
 	}
 	return bIsNewFlow;
 }


### PR DESCRIPTION
SwitchFlowToPath swallows the first few lines of content after a switch, unnecessarily.

Fix is simply to remove the CanContinueInternal/ContinueInternal

Fixes issue #140 